### PR TITLE
Do not keep session alive

### DIFF
--- a/clock-in.py
+++ b/clock-in.py
@@ -29,6 +29,7 @@ class DaKa(object):
         self.base_url = "https://healthreport.zju.edu.cn/ncov/wap/default/index"
         self.save_url = "https://healthreport.zju.edu.cn/ncov/wap/default/save"
         self.sess = requests.Session()
+        self.sess.keep_alive = False
 
     def login(self):
         """Login to ZJU platform"""


### PR DESCRIPTION
https链接太多没有关闭会导致打卡次数达到一定数量后无法新建连接，使打卡失败